### PR TITLE
fix: Use "rimraf" insted of "rm -rf" on postinstall.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha --require ts-node/register 'lib/**/*.spec.ts'",
     "build": "rollup --config rollup.config.js",
     "prepublishOnly": "npm run build",
-    "postinstall": "rm -rf dist"
+    "postinstall": "rimraf dist"
   },
   "repository": "github:hyperjump-io/json-pointer",
   "keywords": [
@@ -39,6 +39,7 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.24.2",
     "mocha": "^9.1.1",
+    "rimraf": "^3.0.2",
     "rollup": "^2.56.3",
     "rollup-plugin-terser": "^7.0.2",
     "ts-node": "^10.2.1",


### PR DESCRIPTION
Resolves

#5

Proposed Changes

Use "rimraf" insted of "rm -rf" on postinstall.
It works on Windows.